### PR TITLE
SD: Fix initialization for old cards

### DIFF
--- a/Src/stm32h7xx_hal_sd.c
+++ b/Src/stm32h7xx_hal_sd.c
@@ -3151,9 +3151,12 @@ static uint32_t SD_PowerON(SD_HandleTypeDef *hsd)
     return errorstate;
   }
 
+  /* HAL edit 1/23/2024: also check for SDMMC_ERROR_CMD_RSP_TIMEOUT.
+     Older SD cards will fail to init if we don't allow for that error.
+   */
   /* CMD8: SEND_IF_COND: Command available only on V2.0 cards */
   errorstate = SDMMC_CmdOperCond(hsd->Instance);
-  if (errorstate == SDMMC_ERROR_TIMEOUT) /* No response to CMD8 */
+  if (errorstate == SDMMC_ERROR_TIMEOUT || errorstate == SDMMC_ERROR_CMD_RSP_TIMEOUT) /* No response to CMD8 */
   {
     hsd->SdCard.CardVersion = CARD_V1_X;
     /* CMD0: GO_IDLE_STATE */


### PR DESCRIPTION
When initializing an SD card, you are expected to send a command (CMD8) which old cards don't recognize. If the card fails to respond, you can safely assume it's an older (v1) card instead of a newer (v2 or higher) card.

HAL's code to distinguish card versions only checks for `SDMMC_ERROR_TIMEOUT`, but at some point they must have added a more specific timeout error `SDMMC_ERROR_CMD_RSP_TIMEOUT`, then failed to update the SD version detection code, and didn't test against v1 cards.

This seems to fix init problems with v1 cards, and should have no effect on v2 cards.

Reference:
SD Physical Layer Simplified Specification Version 6.00, section 4.3.13